### PR TITLE
Visor Implement Modal Popup On Hotkey Press [sc-1464]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </h1>
 <p align="center">Urbit Visor is an extension which <b>transforms your web browser</b> into a <b>first class Urbit client</b>. Its goal is to allow existing web tech to seamlessly integrate together with the novel functionality of Urbit. </p>
 
-<p align="center"><img src="https://img.shields.io/badge/version-v0.3.1-blue?style=for-the-badge&logo=none" />&nbsp;&nbsp;<img src="https://img.shields.io/badge/license-mit-blue?style=for-the-badge&logo=none" alt="license" /></p>
+<p align="center"><img src="https://img.shields.io/badge/version-v0.3.2-blue?style=for-the-badge&logo=none" />&nbsp;&nbsp;<img src="https://img.shields.io/badge/license-mit-blue?style=for-the-badge&logo=none" alt="license" /></p>
 
 ## Getting Started
 

--- a/visor-extension/public/manifest.json
+++ b/visor-extension/public/manifest.json
@@ -44,9 +44,20 @@
         "chromeos": "Ctrl+Shift+U",
         "linux": "Ctrl+Shift+U"
       }
+    },
+    "command-launcher": {
+      "suggested_key" : {
+        "windows": "Ctrl+Period",
+        "mac": "Ctrl+Period",
+        "chromeos": "Ctrl+Period",
+        "linux": "Ctrl+Period"
+      },
+      "description" : "UV command launcher"
     }
   },
   "permissions": [
-    "storage"
+    "storage",
+    "tabs",
+    "activeTab"
  ]
 }

--- a/visor-extension/src/background.ts
+++ b/visor-extension/src/background.ts
@@ -16,6 +16,7 @@ async function init() {
   storageListener();
   messageListener();
   extensionListener();
+  hotkeyListener();
 };
 init();
 
@@ -56,7 +57,17 @@ function extensionListener() {
     handleVisorCall(request, sender, sendResponse, "extension");
   });
 }
-
+function hotkeyListener() {
+  const showLauncher = () => {
+    const modal: any = <any>document.querySelector('#command-launcher');
+    modal.showModal();
+  }
+  chrome.commands.onCommand.addListener((command, tab) => {
+    chrome.tabs.executeScript(tab.id, {
+	    code: `(${showLauncher})()`
+    });
+  });
+}
 
 function handleInternalMessage(request: UrbitVisorInternalComms, sender: any, sendResponse: any) {
   const state = useStore.getState();

--- a/visor-extension/src/content.ts
+++ b/visor-extension/src/content.ts
@@ -20,8 +20,14 @@ function embed(fn: Function) {
   document.documentElement.appendChild(script);
 }
 
+function appendLauncher() {
+  const modal = document.createElement("dialog");
+  modal.id = "command-launcher";
+  document.body.appendChild(modal);
+}
+appendLauncher();
+
 if (shouldInject()) {
   embed(proofOfVisor)
   Messaging.createProxyController();
 }
-


### PR DESCRIPTION
the hotkey is `ctrl+.` instead of `ctrl+/` because the `chrome.commands` API doesn't allow `/` as hotkey
should I continue doing it with `chrome.commands` API or should I rewrite it using `keydown` event listeners? I don't see using the API having benefits over the latter, it was just easier to implement i guess. event listeners would also allow more freedom to choose hotkeys but also clashes with some webapps (e.g. Landscape also uses `ctrl+/`)